### PR TITLE
Subscriber registry tables

### DIFF
--- a/integration_test.py
+++ b/integration_test.py
@@ -66,8 +66,8 @@ if __name__ == '__main__':
   print 'testing SIPAuthServe subscriber operations:'
   print '  we currently have %s subscribers' % len(response.data)
   print 'creating two subscribers:'
-  subscriber_a = ('jon', 0123, 4567)
-  subscriber_b = ('ada', 8901, 2345, 6789)
+  subscriber_a = ('jon', 0123, 4567, '127.0.0.1', '8888')
+  subscriber_b = ('ada', 8901, 2345, '123.234.123.234', '4321', 6789)
   connection.create_subscriber(*subscriber_a)
   connection.create_subscriber(*subscriber_b)
   response = connection.get_subscribers()

--- a/integration_test.py
+++ b/integration_test.py
@@ -72,6 +72,12 @@ if __name__ == '__main__':
   connection.create_subscriber(*subscriber_b)
   response = connection.get_subscribers()
   print '  we now have %s subscribers' % len(response.data)
+  response = connection.get_subscribers(name='jon')
+  print '  filtering for jon: %s, length: %d' % (response.data[0]['name'], len(response.data))
+  response = connection.read_sip_buddies(['name'], {})
+  print '  getting the sip_buddies names  %s' % response.data
+  response = connection.read_sip_buddies([], {'name': 'jon'})
+  print '  getting the sip_buddies entries for jon len=%s, fields=%s' % (len(response.data), len(response.data[0]))
   print 'deleting those two subscribers:'
   connection.delete_subscriber(imsi=subscriber_a[1])
   connection.delete_subscriber(imsi=subscriber_b[1])

--- a/integration_test.py
+++ b/integration_test.py
@@ -74,6 +74,12 @@ if __name__ == '__main__':
   print '  we now have %s subscribers' % len(response.data)
   response = connection.get_subscribers(name='jon')
   print '  filtering for jon: %s, length: %d' % (response.data[0]['name'], len(response.data))
+  response = connection.update_sip_buddies({'ipaddr': ''},
+          {'name': 'non-existent'})
+  print '  updating nonexistent: %s, code: %d' % (response.data, response.code)
+  response = connection.update_sip_buddies({'name': 'bob'},
+          {'name': 'ada'})
+  print '  updating ada to bob: %s, code: %d' % (response.data, response.code)
   response = connection.read_sip_buddies(['name'], {})
   print '  getting the sip_buddies names  %s' % response.data
   response = connection.read_sip_buddies([], {'name': 'jon'})

--- a/openbts/codes.py
+++ b/openbts/codes.py
@@ -1,0 +1,25 @@
+"""openbts.codes
+response codes returned by NodeManager
+"""
+from enum import IntEnum
+
+class OpenBTSCode(IntEnum):
+    """Generic OpenBTS response code"""
+    pass
+
+class SuccessCode(OpenBTSCode):
+    """Codes that are associated with a successful Nodemanager request.
+    """
+    OK = 200
+    NoContent = 204
+
+class ErrorCode(OpenBTSCode):
+    """Codes that are associated with a failed Nodemanager request.
+    """
+    NotFound = 404
+    InvalidRequest = 406
+    ConflictingValue = 409
+    StoreFailed = 500
+    UnknownAction = 501
+    ServiceUnavailable = 503
+

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -129,26 +129,21 @@ class SIPAuthServe(BaseComponent):
     response = self._send_and_receive(message)
     return response
 
-  def update_subscriber(self, new_name=None, new_msisdn=None, imsi=None):
+  def update_subscriber(self, new_name, new_msisdn, imsi):
     """Update a subscriber by IMSI.
 
     Args:
       imsi: the IMSI of the to-be-updated subscriber
-      new_name: the new name value or None
-      new_msisdn: the new number or None
+      new_name: the new name value
+      new_msisdn: the new number
 
     Returns:
       Response instance
+
+    Raises:
+      InvalidRequestError: if a field is missing or request failed
+      InvalidResponseError: if the operation failed
     """
-
-    # verify qualfiers (node manager needs all credentials)
-    resp = self.get_subscribers(imsi=imsi)
-    if len(resp.data) != 1:
-        raise InvalidRequestError("updating non-unique subscriber")
-
-    # node manager wants both fields
-    name = new_name if new_name else resp.data[0]['name']
-    msisdn = new_msisdn if new_msisdn else resp.data[0]['msisdn']
 
     message = {
       'command': 'subscribers',
@@ -157,8 +152,8 @@ class SIPAuthServe(BaseComponent):
           'imsi': imsi
        },
       'fields': {
-          'name': name,
-          'msisdn': msisdn
+          'name': new_name,
+          'msisdn': new_msisdn
        }
     }
     return self._send_and_receive(message)

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -153,9 +153,14 @@ class SIPAuthServe(BaseComponent):
     message = {
       'command': 'subscribers',
       'action': 'update',
-      'match': {'imsi': imsi},
-      'fields': {'name': name, 'msisdn': msisdn}
-      }
+      'match': {
+          'imsi': imsi
+       },
+      'fields': {
+          'name': name,
+          'msisdn': msisdn
+       }
+    }
     return self._send_and_receive(message)
 
   def read_dialdata(self, fields, qualifier):

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -269,7 +269,7 @@ class SIPAuthServe(BaseComponent):
 
     # this is the only check we really need to do on the client
     # node manager will handle the rest
-    if table_name not in ('sip_buddies', 'dialdata_table', 'RRLP'):
+    if table_name not in ('sip_buddies', 'dialdata_table'):
         raise InvalidRequestError('Invalid SR table name')
     if (fields is not None and not isinstance(fields, list)) \
             or not isinstance(qualifier, dict):
@@ -279,11 +279,8 @@ class SIPAuthServe(BaseComponent):
       'command': table_name,
       'action': 'read',
       'match': qualifier,
+      'fields': fields,
     }
-
-    # specify the fields we want or get them all
-    if fields is not None:
-        message['fields'] = fields
 
     return self._send_and_receive(message)
 

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -81,7 +81,7 @@ class SIPAuthServe(BaseComponent):
     response = self._send_and_receive(message)
     return response
 
-  def create_subscriber(self, name, imsi, msisdn, ki=''):
+  def create_subscriber(self, name, imsi, msisdn, ipaddr, port, ki=''):
     """Add a subscriber.
 
     If the 'ki' argument is given, OpenBTS will use full auth.  Otherwise the
@@ -92,6 +92,8 @@ class SIPAuthServe(BaseComponent):
       name: name of the subscriber
       imsi: IMSI of the subscriber
       msisdn: MSISDN of the subscriber
+      ip: IP of the subscriber
+      port: port of the subscriber
       ki: authentication key of the subscriber
 
     Returns:
@@ -104,6 +106,8 @@ class SIPAuthServe(BaseComponent):
         'name': name,
         'imsi': str(imsi),
         'msisdn': str(msisdn),
+        'ipaddr': str(ipaddr),
+        'port': str(port),
         'ki': str(ki)
       }
     }
@@ -129,13 +133,15 @@ class SIPAuthServe(BaseComponent):
     response = self._send_and_receive(message)
     return response
 
-  def update_subscriber(self, new_name, new_msisdn, imsi):
+  def update_subscriber(self, new_name, new_msisdn, new_ipaddr, new_port, imsi):
     """Update a subscriber by IMSI.
 
     Args:
       imsi: the IMSI of the to-be-updated subscriber
       new_name: the new name value
       new_msisdn: the new number
+      new_ipaddr: the new ipaddr
+      new_port: the new port
 
     Returns:
       Response instance
@@ -153,7 +159,9 @@ class SIPAuthServe(BaseComponent):
        },
       'fields': {
           'name': new_name,
-          'msisdn': new_msisdn
+          'msisdn': new_msisdn,
+          'ipaddr': new_ipaddr,
+          'port': new_port
        }
     }
     return self._send_and_receive(message)

--- a/openbts/core.py
+++ b/openbts/core.py
@@ -24,6 +24,7 @@ class BaseComponent(object):
     # the component inheriting from BaseComponent should call connect on this
     # socket with the appropriate address
     self.socket = context.socket(zmq.REQ)
+    self.socket.setsockopt(zmq.LINGER, 0) # zmq.LINGER sets a timeout for socket.send
     self.socket_timeout = kwargs.pop('socket_timeout', 10)
 
   def create_config(self, key, value):

--- a/openbts/core.py
+++ b/openbts/core.py
@@ -178,7 +178,8 @@ class Response(object):
       if data['code'] == 404:
         raise InvalidRequestError('not found')
       elif data['code'] == 406:
-        raise InvalidRequestError(data['data'])
+        msg = data['data'] if 'data' in data else 'invalid value'
+        raise InvalidRequestError(msg)
       elif data['code'] == 409:
         # TODO(matt): if creating config values isn't possible, will we ever
         #             see the 409 code?

--- a/openbts/core.py
+++ b/openbts/core.py
@@ -176,9 +176,9 @@ class Response(object):
     # if the request failed for some reason, raise an error
     if data['code'] in self.error_codes:
       if data['code'] == 404:
-        raise InvalidRequestError('unknown key')
+        raise InvalidRequestError('not found')
       elif data['code'] == 406:
-        raise InvalidRequestError('invalid value')
+        raise InvalidRequestError(data['data'])
       elif data['code'] == 409:
         # TODO(matt): if creating config values isn't possible, will we ever
         #             see the 409 code?

--- a/openbts/core.py
+++ b/openbts/core.py
@@ -8,6 +8,7 @@ import zmq
 
 from openbts.exceptions import (InvalidRequestError, InvalidResponseError,
                                 TimeoutError)
+from openbts.codes import (SuccessCode, ErrorCode)
 
 class BaseComponent(object):
   """Manages a zeromq connection.
@@ -158,34 +159,30 @@ class Response(object):
     dirty: boolean that, if True, indicates that the command will take effect
         only when the component is restarted
   """
-
-  success_codes = [200, 304, 204]
-  error_codes = [404, 406, 409, 500]
-
   def __init__(self, raw_response_data):
     data = json.loads(raw_response_data)
     if 'code' not in data.keys():
       raise InvalidResponseError('key "code" not in raw response: "%s"' %
                                  raw_response_data)
     # if the request was successful, create a response object and exit
-    if data['code'] in self.success_codes:
-      self.code = data['code']
+    if data['code'] in list(SuccessCode):
+      self.code = SuccessCode(data['code'])
       self.data = data.get('data', None)
       self.dirty = data.get('dirty', None)
       return
 
     # if the request failed for some reason, raise an error
-    if data['code'] in self.error_codes:
-      if data['code'] == 404:
+    if data['code'] in list(ErrorCode):
+      if data['code'] == ErrorCode.NotFound:
         raise InvalidRequestError('not found')
-      elif data['code'] == 406:
+      elif data['code'] == ErrorCode.InvalidRequest:
         msg = data['data'] if 'data' in data else 'invalid value'
         raise InvalidRequestError(msg)
-      elif data['code'] == 409:
+      elif data['code'] == ErrorCode.ConflictingValue:
         # TODO(matt): if creating config values isn't possible, will we ever
         #             see the 409 code?
         raise InvalidRequestError('conflicting value')
-      elif data['code'] == 500:
+      elif data['code'] == ErrorCode.StoreFailed:
         raise InvalidRequestError('storing new value failed')
     # handle unknown response codes
     else:

--- a/openbts/tests/base_component_tests.py
+++ b/openbts/tests/base_component_tests.py
@@ -11,7 +11,7 @@ import zmq
 
 from openbts.core import BaseComponent
 from openbts.exceptions import TimeoutError
-
+from openbts.codes import (SuccessCode, ErrorCode)
 
 class BaseComponentTestCase(unittest.TestCase):
   """Testing the core.BaseComponent class.

--- a/openbts/tests/openbts_component_tests.py
+++ b/openbts/tests/openbts_component_tests.py
@@ -9,6 +9,7 @@ import mock
 
 from openbts.components import OpenBTS
 from openbts.exceptions import InvalidRequestError
+from openbts.codes import (SuccessCode, ErrorCode)
 
 
 class OpenBTSNominalConfigTestCase(unittest.TestCase):
@@ -49,7 +50,7 @@ class OpenBTSNominalConfigTestCase(unittest.TestCase):
     # we should have touched the socket again to receive the reply
     self.assertTrue(self.openbts_connection.socket.recv.called)
     # verify we received a valid response
-    self.assertEqual(response.code, 204)
+    self.assertEqual(response.code, SuccessCode.NoContent)
 
   def test_update_config(self):
     """Updating a key should send a message over zmq and get a response."""
@@ -79,7 +80,7 @@ class OpenBTSNominalConfigTestCase(unittest.TestCase):
       'data': 'sample'
     })
     response = self.openbts_connection.read_config('sample-key')
-    self.assertEqual(response.code, 200)
+    self.assertEqual(response.code, SuccessCode.OK)
 
   def test_responses_with_no_data_param(self):
     """We should handle responses that don't have the 'data' attribute."""
@@ -87,7 +88,7 @@ class OpenBTSNominalConfigTestCase(unittest.TestCase):
       'code': 200,
     })
     response = self.openbts_connection.read_config('sample-key')
-    self.assertEqual(response.code, 200)
+    self.assertEqual(response.code, SuccessCode.OK)
 
 
 class OpenBTSOffNominalConfigTestCase(unittest.TestCase):

--- a/openbts/tests/sipauthserve_component_tests.py
+++ b/openbts/tests/sipauthserve_component_tests.py
@@ -377,7 +377,7 @@ class SIPAuthServeNominalSubscriberRegistryTestCase(unittest.TestCase):
     })
 
   def test_read_subscriber_registry(self):
-    """Requesting a table from the subsciber registry should send a message 
+    """Requesting a table entry from the subsciber registry should send a message
     over zmq and get a response.
     """
     self.sipauthserve_connection.socket.recv.return_value = json.dumps({
@@ -399,7 +399,7 @@ class SIPAuthServeNominalSubscriberRegistryTestCase(unittest.TestCase):
     self.assertEqual(response.code, SuccessCode.OK)
 
   def test_update_subscriber_registry(self):
-    """Requesting a table from the subsciber registry should send a message 
+    """Updating a table entry the subsciber registry should send a message
     over zmq and get a response.
     """
     self.sipauthserve_connection.socket.recv.return_value = json.dumps({

--- a/openbts/tests/smqueue_component_tests.py
+++ b/openbts/tests/smqueue_component_tests.py
@@ -9,6 +9,7 @@ import mock
 
 from openbts.components import SMQueue
 from openbts.exceptions import InvalidRequestError
+from openbts.codes import (SuccessCode, ErrorCode)
 
 
 class SMQueueNominalConfigTestCase(unittest.TestCase):
@@ -49,7 +50,7 @@ class SMQueueNominalConfigTestCase(unittest.TestCase):
     # we should have touched the socket again to receive the reply
     self.assertTrue(self.smqueue_connection.socket.recv.called)
     # verify we received a valid response
-    self.assertEqual(response.code, 204)
+    self.assertEqual(response.code, SuccessCode.NoContent)
 
   def test_update_config(self):
     """Updating a key should send a message over zmq and get a response."""
@@ -65,7 +66,7 @@ class SMQueueNominalConfigTestCase(unittest.TestCase):
     self.assertEqual(self.smqueue_connection.socket.send.call_args[0],
                      (expected_message,))
     self.assertTrue(self.smqueue_connection.socket.recv.called)
-    self.assertEqual(response.code, 204)
+    self.assertEqual(response.code, SuccessCode.NoContent)
 
   def test_delete_config_raises_error(self):
     """Deleting a config key should is not yet supported via NodeManager."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-argparse==1.2.1
-distribute==0.6.24
-mock==1.0.1
-nose==1.3.4
-pyzmq==14.4.0
-wsgiref==0.1.2
+argparse
+distribute
+mock
+nose
+pyzmq
+wsgiref
+enum34

--- a/setup.py
+++ b/setup.py
@@ -13,12 +13,12 @@ with open('readme.md') as f:
 
 setup(
     name='openbts',
-    version='0.0.3',
+    version='0.0.4',
     description='OpenBTS NodeManager client',
     long_description=readme,
     url='http://github.com/yosemitebandit/openbts-python',
     download_url='https://github.com/yosemitebandit/openbts-python/tarball/'
-                 '0.0.3',
+                 '0.0.4',
     author='Matt Ball',
     author_email='matt.ball.2@gmail.com',
     license='MIT',


### PR DESCRIPTION
- Adding filtering to `get_subscribers` based on IMSI, phone number, and/or name.
  - Needs [1fe40d7d0e73ac1a28a5707b5f4ed07dfcef9dd3](https://github.com/endaga/NodeManager/commit/1fe40d7d0e73ac1a28a5707b5f4ed07dfcef9dd3)
- Updating individual subscriber is now a thing
- Read and write to `sip_buddies` and `dialdata_table` directly. 
  - Needs [95dd726c58d3a25a039bcff14f4f8bcd889a09db](https://github.com/endaga/subscriberRegistry/commit/95dd726c58d3a25a039bcff14f4f8bcd889a09db)
