### PR TITLE
adding tests for delete subscriber

### DIFF
--- a/openbts/core.py
+++ b/openbts/core.py
@@ -184,6 +184,10 @@ class Response(object):
         raise InvalidRequestError('conflicting value')
       elif data['code'] == ErrorCode.StoreFailed:
         raise InvalidRequestError('storing new value failed')
+      elif data['code'] == ErrorCode.ServiceUnavailable:
+        raise InvalidRequestError('service unavailable')
+      elif data['code'] == ErrorCode.UnknownAction:
+        raise InvalidRequestError('unknown action')
     # handle unknown response codes
     else:
       raise InvalidResponseError('code "%s" not known' % data['code'])

--- a/openbts/tests/sipauthserve_component_tests.py
+++ b/openbts/tests/sipauthserve_component_tests.py
@@ -359,6 +359,18 @@ class SIPAuthServeNonNominalSubscriberTestCase(unittest.TestCase):
     self.assertTrue(self.sipauthserve_connection.socket.recv.called)
     self.assertEqual(response.code, SuccessCode.OK)
 
+  def test_delete_subscriber_when_sqlite_unavailable(self):
+    """Testing the subscriber deletion case when OpenBTS reports sqlite is unavailble"""
+    self.sipauthserve_connection.socket.recv.return_value = json.dumps({
+      'code': 503,
+      'data': { 'sip_buddies': 'something bad',
+                'dialdata_table': 'this could be ok'
+              }
+      })
+
+    with self.assertRaises(InvalidRequestError):
+        response = self.sipauthserve_connection.delete_subscriber(310150123456789)
+
 class SIPAuthServeNominalSubscriberRegistryTestCase(unittest.TestCase):
   """Testing the components.SIPAuthServe class.
 


### PR DESCRIPTION
This puts in a test for deleting subscribers when sqlite is unavailable for some reason
