### PR TITLE
correctly handle caller IDs

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -87,9 +87,10 @@ class SIPAuthServeTest(unittest.TestCase):
   """Testing SIPAuthServe subscriber and number operations."""
 
   def setUp(self):
-    self.conn = openbts.components.SIPAuthServe()
+    self.conn = openbts.components.SIPAuthServe(socket_timeout=0.1)
     self.sub_a_imsi = 'IMSI000123'
     self.sub_b_imsi = 'IMSI000789'
+    self.tearDown()
     self.conn.create_subscriber(self.sub_a_imsi, '5551234', '127.0.0.1',
                                 '8888')
     self.conn.create_subscriber(self.sub_b_imsi, '5556789', '123.234.123.234',

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -178,7 +178,7 @@ class SIPAuthServeTest(unittest.TestCase):
 
   def test_delete_last_number(self):
     with self.assertRaises(ValueError):
-      self.conn.delete_number(self.sub_a_imsi, '5556789')
+      self.conn.delete_number(self.sub_a_imsi, '5551234')
 
   def test_delete_single_number(self):
     self.conn.add_number(self.sub_a_imsi, '5557744')

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -12,8 +12,9 @@ class OpenBTS(BaseComponent):
     address: tcp socket for the zmq connection
   """
 
-  def __init__(self, address='tcp://127.0.0.1:45060'):
-    super(OpenBTS, self).__init__()
+  def __init__(self, **kwargs):
+    address = kwargs.pop('address', 'tcp://127.0.0.1:45060')
+    super(OpenBTS, self).__init__(**kwargs)
     self.socket.connect(address)
 
   def __repr__(self):
@@ -43,8 +44,9 @@ class SIPAuthServe(BaseComponent):
     address: tcp socket for the zmq connection
   """
 
-  def __init__(self, address='tcp://127.0.0.1:45064'):
-    super(SIPAuthServe, self).__init__()
+  def __init__(self, **kwargs):
+    address = kwargs.pop('address', 'tcp://127.0.0.1:45064')
+    super(SIPAuthServe, self).__init__(**kwargs)
     self.socket.connect(address)
 
   def __repr__(self):
@@ -348,8 +350,9 @@ class SMQueue(BaseComponent):
     address: tcp socket for the zmq connection
   """
 
-  def __init__(self, address='tcp://127.0.0.1:45063'):
-    super(SMQueue, self).__init__()
+  def __init__(self, **kwargs):
+    address = kwargs.pop('address', 'tcp://127.0.0.1:45063')
+    super(SMQueue, self).__init__(**kwargs)
     self.socket.connect(address)
 
   def __repr__(self):

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -222,6 +222,9 @@ class SIPAuthServe(BaseComponent):
     subscriber's name === their imsi.  Some things in NM are keyed on 'name'
     however, so we have to use both when making queries and updates.
 
+    In calling this method we let NodeManager automatically set the sip_buddies
+    callerid field to equal the providied msisdn.
+
     If the 'ki' argument is given, OpenBTS will use full auth.  Otherwise the
     system will use cache auth.  The values of IMSI, MSISDN and ki will all
     be cast to strings before the message is sent.

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -189,12 +189,16 @@ class SIPAuthServe(BaseComponent):
   def delete_number(self, imsi, number):
     """De-associate a number with an IMSI."""
     # First see if the number is attached to the subscriber.
-    if number not in self.get_numbers(imsi):
+    numbers = self.get_numbers(imsi)
+    if number not in numbers:
       raise ValueError('number %s not attached to IMSI %s' % (number, imsi))
+    # Check if this is the only associated number.
+    if len(numbers) == 1:
+      raise ValueError('cannot delete number %s as it is the only number'
+                       ' associated with IMSI %s' % (number, imsi))
     # See if this number is the caller ID.  If it is, promote another number
     # to be caller ID.
     if number == self.get_caller_id(imsi):
-      numbers = self.get_numbers(imsi)
       numbers.remove(number)
       new_caller_id = numbers[-1]
       self.update_caller_id(imsi, new_caller_id)

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ MIT
 
 
 ### releases
+* 0.0.12 - correctly handles `caller_id` in get / update / delete operations
 * 0.0.11 - `get_subscribers` returns `account_balance` info for each subscriber
 * 0.0.10 - adds read and update operations on subscriber `account_balance`
 * 0.0.9 - prevents `create_subscriber` from adding duplicate IMSIs

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open('requirements.txt') as f:
 with open('readme.md') as f:
   readme = f.read()
 
-version = '0.0.11'
+version = '0.0.12'
 
 setup(
     name='openbts',


### PR DESCRIPTION
PTAL -- also fixes kwarg passing in components and a number deletion test
