### PR TITLE
adds envoy to setup.py as it is a runtime dep

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ MIT
 
 
 ### releases
+* 0.0.16 - adds `envoy` to `setup.py`
 * 0.0.15 - get GPRS information (experimental); prefixes other ipaddr and port attributes with `openbts_`
 * 0.0.14 - `get_numbers` returns an empty list instead of raising if no number is found for an IMSI
 * 0.0.13 - fixes `get_subscriber` and `create_subscriber` for the latest NM

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with open('readme.md') as f:
   readme = f.read()
 
-version = '0.0.15'
+version = '0.0.16'
 
 setup(
     name='openbts',
@@ -21,6 +21,10 @@ setup(
     author_email='matt@endaga.com',
     license='MIT',
     packages=['openbts'],
-    install_requires=["enum34==1.0.4", "pyzmq==14.5.0"],
+    install_requires=[
+        "enum34==1.0.4",
+        "envoy==0.0.3",
+        "pyzmq==14.5.0",
+    ],
     zip_safe=False
 )


### PR DESCRIPTION
PTAL -- randomly realized envoy was missing from the runtime deps in `setup.py` here
