### PR TITLE
Add rcvtime0 socket option

### DIFF
--- a/openbts/components.py
+++ b/openbts/components.py
@@ -18,8 +18,8 @@ class OpenBTS(BaseComponent):
   """
 
   def __init__(self, **kwargs):
-    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45060')
     super(OpenBTS, self).__init__(**kwargs)
+    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45060')
     self.socket.connect(self.address)
 
   def __repr__(self):
@@ -50,8 +50,8 @@ class SIPAuthServe(BaseComponent):
   """
 
   def __init__(self, **kwargs):
-    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45064')
     super(SIPAuthServe, self).__init__(**kwargs)
+    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45064')
     self.socket.connect(self.address)
 
   def __repr__(self):
@@ -472,8 +472,8 @@ class SMQueue(BaseComponent):
   """
 
   def __init__(self, **kwargs):
-    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45063')
     super(SMQueue, self).__init__(**kwargs)
+    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45063')
     self.socket.connect(self.address)
 
   def __repr__(self):

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -18,9 +18,9 @@ class OpenBTS(BaseComponent):
   """
 
   def __init__(self, **kwargs):
-    address = kwargs.pop('address', 'tcp://127.0.0.1:45060')
+    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45060')
     super(OpenBTS, self).__init__(**kwargs)
-    self.socket.connect(address)
+    self.socket.connect(self.address)
 
   def __repr__(self):
     return 'OpenBTS component'
@@ -50,9 +50,9 @@ class SIPAuthServe(BaseComponent):
   """
 
   def __init__(self, **kwargs):
-    address = kwargs.pop('address', 'tcp://127.0.0.1:45064')
+    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45064')
     super(SIPAuthServe, self).__init__(**kwargs)
-    self.socket.connect(address)
+    self.socket.connect(self.address)
 
   def __repr__(self):
     return 'SIPAuthServe component'
@@ -472,9 +472,9 @@ class SMQueue(BaseComponent):
   """
 
   def __init__(self, **kwargs):
-    address = kwargs.pop('address', 'tcp://127.0.0.1:45063')
+    self.address = kwargs.pop('address', 'tcp://127.0.0.1:45063')
     super(SMQueue, self).__init__(**kwargs)
-    self.socket.connect(address)
+    self.socket.connect(self.address)
 
   def __repr__(self):
     return 'SMQueue component'

--- a/openbts/core.py
+++ b/openbts/core.py
@@ -23,6 +23,9 @@ class BaseComponent(object):
   def __init__(self, **kwargs):
     self.address = None
     self.setup_socket()
+    # The socket will poll for this amount of time and recv if there is a
+    # response available.
+    self.socket_timeout = kwargs.pop('socket_timeout', 10)  # seconds
 
   def setup_socket(self):
     """Sets up the ZMQ socket."""
@@ -34,9 +37,6 @@ class BaseComponent(object):
     self.socket.setsockopt(zmq.LINGER, 0)
     # RCVTIME0 sets a timeout for socket.recv.
     self.socket.setsockopt(zmq.RCVTIMEO, 500)  # milliseconds
-    # The socket will poll for this amount of time and recv if there is a
-    # response available.
-    self.socket_timeout = kwargs.pop('socket_timeout', 10)  # seconds
 
   def create_config(self, key, value):
     """Create a config parameter and initialize it.

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ MIT
 
 
 ### releases
+* 0.0.17 - sets `RCVTIME0` on zmq sockets
 * 0.0.16 - adds `envoy` to `setup.py`
 * 0.0.15 - get GPRS information (experimental); prefixes other ipaddr and port attributes with `openbts_`
 * 0.0.14 - `get_numbers` returns an empty list instead of raising if no number is found for an IMSI

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 with open('readme.md') as f:
   readme = f.read()
 
-version = '0.0.16'
+version = '0.0.17'
 
 setup(
     name='openbts',


### PR DESCRIPTION
PTAL

I've been having issues where the zmq socket gets in a bad state (getting the error `ZMQError: Operation cannot be accomplished in current state`).  This PR adds the `RCVTIME0` socket option as recommended [here](http://stackoverflow.com/questions/26915347/zeromq-reset-req-rep-socket-state).
