### PR TITLE
Adjust socket handling

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -37,15 +37,18 @@ class ConfigReadTest(unittest.TestCase):
 
   def test_read_openbts_config(self):
     connection = openbts.components.OpenBTS()
-    connection.read_config('Control.NumSQLTries')
+    response = connection.read_config('Control.NumSQLTries')
+    self.assertTrue(isinstance(response.data, dict))
 
   def test_read_sipauthserve_config(self):
     connection = openbts.components.SIPAuthServe()
-    connection.read_config('Log.Alarms.Max')
+    response = connection.read_config('Log.Alarms.Max')
+    self.assertTrue(isinstance(response.data, dict))
 
   def test_read_smqueue_config(self):
     connection = openbts.components.SMQueue()
-    connection.read_config('Bounce.Code')
+    response = connection.read_config('Bounce.Code')
+    self.assertTrue(isinstance(response.data, dict))
 
 
 class ConfigUpdateTest(unittest.TestCase):

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -19,17 +19,17 @@ class VersionTest(unittest.TestCase):
   def test_query_openbts_version(self):
     connection = openbts.components.OpenBTS()
     response = connection.get_version()
-    self.assertTrue(str, isinstance(response.data))
+    self.assertTrue(isinstance(response.data, unicode))
 
   def test_query_sipauthserve_version(self):
     connection = openbts.components.SIPAuthServe()
     response = connection.get_version()
-    self.assertTrue(str, isinstance(response.data))
+    self.assertTrue(isinstance(response.data, unicode))
 
   def test_query_smqueue_version(self):
     connection = openbts.components.SMQueue()
     response = connection.get_version()
-    self.assertTrue(str, isinstance(response.data))
+    self.assertTrue(isinstance(response.data, unicode))
 
 
 class ConfigReadTest(unittest.TestCase):

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -20,7 +20,6 @@ class OpenBTS(BaseComponent):
   def __init__(self, **kwargs):
     super(OpenBTS, self).__init__(**kwargs)
     self.address = kwargs.pop('address', 'tcp://127.0.0.1:45060')
-    self.socket.connect(self.address)
 
   def __repr__(self):
     return 'OpenBTS component'
@@ -52,7 +51,6 @@ class SIPAuthServe(BaseComponent):
   def __init__(self, **kwargs):
     super(SIPAuthServe, self).__init__(**kwargs)
     self.address = kwargs.pop('address', 'tcp://127.0.0.1:45064')
-    self.socket.connect(self.address)
 
   def __repr__(self):
     return 'SIPAuthServe component'
@@ -474,7 +472,6 @@ class SMQueue(BaseComponent):
   def __init__(self, **kwargs):
     super(SMQueue, self).__init__(**kwargs)
     self.address = kwargs.pop('address', 'tcp://127.0.0.1:45063')
-    self.socket.connect(self.address)
 
   def __repr__(self):
     return 'SMQueue component'

--- a/openbts/core.py
+++ b/openbts/core.py
@@ -10,6 +10,7 @@ from openbts.exceptions import (InvalidRequestError, InvalidResponseError,
                                 TimeoutError)
 from openbts.codes import (SuccessCode, ErrorCode)
 
+
 class BaseComponent(object):
   """Manages a zeromq connection.
 
@@ -142,7 +143,7 @@ class BaseComponent(object):
     Raises:
       TimeoutError: if nothing is received for the timeout
     """
-    # send the message and poll for responses
+    # Send the message and poll for responses.
     self.socket.send(json.dumps(message))
     responses = self.socket.poll(timeout=self.socket_timeout * 1000)
     if responses:
@@ -182,14 +183,14 @@ class Response(object):
     if 'code' not in data.keys():
       raise InvalidResponseError('key "code" not in raw response: "%s"' %
                                  raw_response_data)
-    # if the request was successful, create a response object and exit
+    # If the request was successful, create a response object and exit.
     if data['code'] in list(SuccessCode):
       self.code = SuccessCode(data['code'])
       self.data = data.get('data', None)
       self.dirty = data.get('dirty', None)
       return
 
-    # if the request failed for some reason, raise an error
+    # If the request failed for some reason, raise an error.
     if data['code'] in list(ErrorCode):
       if data['code'] == ErrorCode.NotFound:
         raise InvalidRequestError('not found')
@@ -206,6 +207,6 @@ class Response(object):
         raise InvalidRequestError('service unavailable')
       elif data['code'] == ErrorCode.UnknownAction:
         raise InvalidRequestError('unknown action')
-    # handle unknown response codes
+    # Handle unknown response codes.
     else:
       raise InvalidResponseError('code "%s" not known' % data['code'])

--- a/openbts/tests/base_component_tests.py
+++ b/openbts/tests/base_component_tests.py
@@ -13,6 +13,7 @@ from openbts.core import BaseComponent
 from openbts.exceptions import TimeoutError
 from openbts.codes import (SuccessCode, ErrorCode)
 
+
 class BaseComponentTestCase(unittest.TestCase):
   """Testing the core.BaseComponent class.
 
@@ -21,7 +22,7 @@ class BaseComponentTestCase(unittest.TestCase):
   server in another process and then connect through a test client.
   """
 
-  # demo server will wait this many seconds before replying
+  # The demo server will wait this many seconds before replying.
   RESPONSE_DELAY = 0.1
   DEMO_ADDRESS = 'tcp://127.0.0.1:7890'
 
@@ -32,7 +33,7 @@ class BaseComponentTestCase(unittest.TestCase):
     server_socket.bind(self.DEMO_ADDRESS)
     server_socket.recv()
     response = json.dumps({'code': 200, 'data': 'testing', 'dirty': 0})
-    # delay a bit before sending the reply
+    # Delay a bit before sending the reply.
     time.sleep(self.RESPONSE_DELAY)
     server_socket.send(response)
 
@@ -48,8 +49,8 @@ class BaseComponentTestCase(unittest.TestCase):
 
   def test_socket_timeout(self):
     """Base socket should raise a TimeoutError after receiving no reply."""
-    # server will delay before sending response
-    # so we set the timeout to be a bit less than that amount
+    # The server will delay before sending response so we set the timeout to be
+    # a bit less than that delay.
     component = BaseComponent(socket_timeout=self.RESPONSE_DELAY*0.9)
     component.socket.connect(self.DEMO_ADDRESS)
     with self.assertRaises(TimeoutError):

--- a/openbts/tests/base_component_tests.py
+++ b/openbts/tests/base_component_tests.py
@@ -47,6 +47,13 @@ class BaseComponentTestCase(unittest.TestCase):
     self.demo_server_process.terminate()
     self.demo_server_process.join()
 
+  def test_socket(self):
+    """Base socket should receive a reply with default timeouts."""
+    component = BaseComponent(socket_timeout=10)
+    component.address = self.DEMO_ADDRESS
+    response = component.read_config('sample-key')
+    self.assertTrue(isinstance(response.data, unicode))
+
   def test_socket_timeout(self):
     """Base socket should raise a TimeoutError after receiving no reply."""
     # The server will delay before sending response so we set the timeout to be

--- a/openbts/tests/base_component_tests.py
+++ b/openbts/tests/base_component_tests.py
@@ -52,6 +52,6 @@ class BaseComponentTestCase(unittest.TestCase):
     # The server will delay before sending response so we set the timeout to be
     # a bit less than that delay.
     component = BaseComponent(socket_timeout=self.RESPONSE_DELAY*0.9)
-    component.socket.connect(self.DEMO_ADDRESS)
+    component.address = self.DEMO_ADDRESS
     with self.assertRaises(TimeoutError):
       component.read_config('sample-key')

--- a/openbts/tests/openbts_component_tests.py
+++ b/openbts/tests/openbts_component_tests.py
@@ -9,7 +9,7 @@ import mock
 
 from openbts.components import OpenBTS
 from openbts.exceptions import InvalidRequestError
-from openbts.codes import (SuccessCode, ErrorCode)
+from openbts.codes import SuccessCode
 
 
 class OpenBTSNominalConfigTestCase(unittest.TestCase):
@@ -20,8 +20,14 @@ class OpenBTSNominalConfigTestCase(unittest.TestCase):
 
   def setUp(self):
     self.openbts_connection = OpenBTS()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.openbts_connection.socket = mock.Mock()
+    self.openbts_connection.setup_socket = lambda: True
+    self.openbts_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.openbts_connection.socket.recv.return_value = json.dumps({
       'code': 204,
       'data': 'sample',
@@ -99,8 +105,19 @@ class OpenBTSOffNominalConfigTestCase(unittest.TestCase):
 
   def setUp(self):
     self.openbts_connection = OpenBTS()
-    # mock a zmq socket
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.openbts_connection.socket = mock.Mock()
+    self.openbts_connection.setup_socket = lambda: True
+    self.openbts_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
+    self.openbts_connection.socket.recv.return_value = json.dumps({
+      'code': 204,
+      'data': 'sample',
+      'dirty': 0
+    })
 
   def test_read_config_unknown_key(self):
     """Reading a nonexistent key raises an error."""
@@ -132,8 +149,14 @@ class OpenBTSNominalGetVersionTestCase(unittest.TestCase):
 
   def setUp(self):
     self.openbts_connection = OpenBTS()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.openbts_connection.socket = mock.Mock()
+    self.openbts_connection.setup_socket = lambda: True
+    self.openbts_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.openbts_connection.socket.recv.return_value = json.dumps({
       'code': 200,
       'data': 'release 4.0.0.8025'
@@ -160,8 +183,14 @@ class OpenBTSNominalMonitorTestCase(unittest.TestCase):
 
   def setUp(self):
     self.openbts_connection = OpenBTS()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.openbts_connection.socket = mock.Mock()
+    self.openbts_connection.setup_socket = lambda: True
+    self.openbts_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.openbts_connection.socket.recv.return_value = json.dumps({
       'code': 200,
       'data': {

--- a/openbts/tests/sipauthserve_component_tests.py
+++ b/openbts/tests/sipauthserve_component_tests.py
@@ -20,8 +20,14 @@ class SIPAuthServeNominalConfigTestCase(unittest.TestCase):
 
   def setUp(self):
     self.sipauthserve_connection = SIPAuthServe()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.sipauthserve_connection.socket = mock.Mock()
+    self.sipauthserve_connection.setup_socket = lambda: True
+    self.sipauthserve_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.sipauthserve_connection.socket.recv.return_value = json.dumps({
       'code': 204,
       'data': 'sample',
@@ -83,8 +89,13 @@ class SIPAuthServeOffNominalConfigTestCase(unittest.TestCase):
 
   def setUp(self):
     self.sipauthserve_connection = SIPAuthServe()
-    # mock a zmq socket
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.sipauthserve_connection.socket = mock.Mock()
+    self.sipauthserve_connection.setup_socket = lambda: True
+    self.sipauthserve_connection.teardown_socket = lambda: True
 
   def test_read_config_unknown_key(self):
     """Reading a nonexistent key raises an error."""
@@ -116,8 +127,14 @@ class SIPAuthServeNominalGetVersionTestCase(unittest.TestCase):
 
   def setUp(self):
     self.sipauthserve_connection = SIPAuthServe()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.sipauthserve_connection.socket = mock.Mock()
+    self.sipauthserve_connection.setup_socket = lambda: True
+    self.sipauthserve_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.sipauthserve_connection.socket.recv.return_value = json.dumps({
       'code': 200,
       'data': 'release 7'
@@ -147,8 +164,14 @@ class SIPAuthServeNominalSubscriberTestCase(unittest.TestCase):
 
   def setUp(self):
     self.sipauthserve_connection = SIPAuthServe()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.sipauthserve_connection.socket = mock.Mock()
+    self.sipauthserve_connection.setup_socket = lambda: True
+    self.sipauthserve_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.sipauthserve_connection.socket.recv.return_value = json.dumps({
       'code': 204,
       'data': [{'exten': '5551234', 'name': 'sample'}],
@@ -229,6 +252,7 @@ class SIPAuthServeNominalSubscriberTestCase(unittest.TestCase):
     ]
     self.sipauthserve_connection.create_subscriber(
         310150123456789, 123456789, '127.0.0.1', '1234', ki='abc')
+    # TODO(matt): assert
 
   def test_create_subscriber_sans_ki(self):
     """Creating a subscriber without a specficied ki uses zmq."""
@@ -245,7 +269,7 @@ class SIPAuthServeNominalSubscriberTestCase(unittest.TestCase):
       json.dumps({'code': 200}),
       json.dumps({'code': 200}),
     ]
-    response = self.sipauthserve_connection.create_subscriber(
+    self.sipauthserve_connection.create_subscriber(
         310150123456789, 123456789, '127.0.0.1', '1234')
 
   def test_delete_subscriber_by_imsi(self):
@@ -274,8 +298,14 @@ class SIPAuthServeOffNominalSubscriberTestCase(unittest.TestCase):
 
   def setUp(self):
     self.sipauthserve_connection = SIPAuthServe()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.sipauthserve_connection.socket = mock.Mock()
+    self.sipauthserve_connection.setup_socket = lambda: True
+    self.sipauthserve_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.sipauthserve_connection.socket.recv.return_value = json.dumps({
       'code': 200,
       'data': 'sample',
@@ -302,7 +332,7 @@ class SIPAuthServeOffNominalSubscriberTestCase(unittest.TestCase):
         }
       })
     with self.assertRaises(InvalidRequestError):
-        self.sipauthserve_connection.delete_subscriber(310150123456789)
+      self.sipauthserve_connection.delete_subscriber(310150123456789)
 
 
 class GPRSTest(unittest.TestCase):
@@ -315,6 +345,11 @@ class GPRSTest(unittest.TestCase):
     cls.mock_envoy = mocks.MockEnvoy(return_text=None)
     openbts.components.envoy = cls.mock_envoy
     cls.sipauthserve = SIPAuthServe()
+    # Mock the zmq socket attribute, as well as the setup and teardown_socket
+    # methods.
+    cls.sipauthserve.socket = mock.Mock()
+    cls.sipauthserve.setup_socket = lambda: True
+    cls.sipauthserve.teardown_socket = lambda: True
     # Setup a path to the CLI output.
     cls.cli_output_path = ('openbts/tests/fixtures/'
                            'openbts_cli_gprs_list_output.txt')
@@ -339,7 +374,7 @@ class GPRSTest(unittest.TestCase):
     """We can get all available GPRS connection data."""
     # The command 'gprs list' returns a big string when IPs are assigned.
     with open(self.cli_output_path) as output:
-        self.mock_envoy.return_text = output.read()
+      self.mock_envoy.return_text = output.read()
     expected_usage = {
         'IMSI901550000000022': {
             'ipaddr': '192.168.99.4',
@@ -367,7 +402,7 @@ class GPRSTest(unittest.TestCase):
   def test_specific_imsi(self):
     """We can get data for a specific IMSI."""
     with open(self.cli_output_path) as output:
-        self.mock_envoy.return_text = output.read()
+      self.mock_envoy.return_text = output.read()
     target_imsi = 'IMSI901550000000022'
     expected_usage = {
       'ipaddr': '192.168.99.4',
@@ -380,7 +415,7 @@ class GPRSTest(unittest.TestCase):
   def test_unknown_imsi(self):
     """Unknown IMSIs will return None."""
     with open(self.cli_output_path) as output:
-        self.mock_envoy.return_text = output.read()
+      self.mock_envoy.return_text = output.read()
     target_imsi = 'IMSI000123'
     expected_usage = None
     self.assertEqual(expected_usage,

--- a/openbts/tests/smqueue_component_tests.py
+++ b/openbts/tests/smqueue_component_tests.py
@@ -20,8 +20,14 @@ class SMQueueNominalConfigTestCase(unittest.TestCase):
 
   def setUp(self):
     self.smqueue_connection = SMQueue()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.smqueue_connection.socket = mock.Mock()
+    self.smqueue_connection.setup_socket = lambda: True
+    self.smqueue_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.smqueue_connection.socket.recv.return_value = json.dumps({
       'code': 204,
       'data': 'sample',
@@ -82,8 +88,13 @@ class SMQueueOffNominalConfigTestCase(unittest.TestCase):
 
   def setUp(self):
     self.smqueue_connection = SMQueue()
-    # mock a zmq socket
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.smqueue_connection.socket = mock.Mock()
+    self.smqueue_connection.setup_socket = lambda: True
+    self.smqueue_connection.teardown_socket = lambda: True
 
   def test_read_config_unknown_key(self):
     """Reading a nonexistent key raises an error."""
@@ -115,8 +126,14 @@ class SMQueueNominalGetVersionTestCase(unittest.TestCase):
 
   def setUp(self):
     self.smqueue_connection = SMQueue()
-    # mock a zmq socket with a simple recv return value
+    # Mock the zmq socket attribute, as well as the setup_socket method.  We'll
+    # also prevent the socket from being nullified by mocking the
+    # teardown_socket method, allowing us to inspect the data sent to the
+    # socket.
     self.smqueue_connection.socket = mock.Mock()
+    self.smqueue_connection.setup_socket = lambda: True
+    self.smqueue_connection.teardown_socket = lambda: True
+    # Create a mock return value for the socket.
     self.smqueue_connection.socket.recv.return_value = json.dumps({
       'code': 200,
       'data': 'release 4'

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,15 @@
+[FORMAT]
+# the string used as indentation unit
+indent-string='  '
+# spaces of indent required inside a hanging or continued line
+indent-after-paren=2
+
+
+[MESSAGES CONTROL]
+# http://pylint-messages.wikidot.com/all-messages
+# W0621: Redefining name %r from outer scope (line %s)
+# C0103: Invalid %s name "%s"
+# W0141: Used builtin function %r
+# C0330: Wrong hanging indentation
+# W0142: Used * or ** magic
+disable=W0621,C0103,W0141,C0330,W0142

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,13 @@ openbts-python package definition
 """
 from setuptools import setup
 
-# load the readme
+
 with open('readme.md') as f:
   readme = f.read()
 
-version = '0.0.17'
+
+version = '0.0.18'
+
 
 setup(
     name='openbts',


### PR DESCRIPTION
wip..
- adjusts socket handling such that we destroy the socket and zmq context after every request and build it before every request
- accordingly adjusts several unit tests
- fixes some integration tests that had bad/no assertions
- adds a new nominal socket test
- adds a pylintrc
- spurious ws / comment adjustments
