### PR TITLE
Exposing tmsis command

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -86,6 +86,7 @@ class OpenBTSMonitoringTest(unittest.TestCase):
     response = connection.monitor()
     self.assertIn('noiseRSSI', response.data)
 
+
 class OpenBTSTMSITableTest(unittest.TestCase):
   """Tests the TMSI table functionality"""
 
@@ -95,6 +96,7 @@ class OpenBTSTMSITableTest(unittest.TestCase):
     connection = openbts.components.OpenBTS()
     response = connection.tmsis()
     self.assertEqual(list, type(response))
+
 
 class SIPAuthServeTest(unittest.TestCase):
   """Testing SIPAuthServe subscriber and number operations."""

--- a/integration_tests.py
+++ b/integration_tests.py
@@ -86,6 +86,15 @@ class OpenBTSMonitoringTest(unittest.TestCase):
     response = connection.monitor()
     self.assertIn('noiseRSSI', response.data)
 
+class OpenBTSTMSITableTest(unittest.TestCase):
+  """Tests the TMSI table functionality"""
+
+  def test_tmsi_table(self):
+    """This test is pretty primitive since we can't add TMSI entries
+    from python yet."""
+    connection = openbts.components.OpenBTS()
+    response = connection.tmsis()
+    self.assertEqual(list, type(response))
 
 class SIPAuthServeTest(unittest.TestCase):
   """Testing SIPAuthServe subscriber and number operations."""

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -41,6 +41,40 @@ class OpenBTS(BaseComponent):
     }
     return self._send_and_receive(message)
 
+  def tmsis(self):
+    """Gets all active subscribers from the TMSI table
+
+    Will return a list of objects of the form: {
+            'A5_SUPPORT' : '',
+            'ACCESSED' : '33m',
+            'ASSERTED_IDENTITY' : '',
+            'ASSOCIATED_URI' : '',
+            'AUTH' : '2',
+            'AUTH_EXPIRY' : '-',
+            'CREATED' : '33m',
+            'IMEI' : '356118040100460',
+            'IMSI' : '901550000000084',
+            'OLD_LAC' : '1000',
+            'OLD_MCC' : '901',
+            'OLD_MNC' : '55',
+            'OLD_TMSI' : '0',
+            'POWER_CLASS' : '',
+            'PTMSI_ASSIGNED' : '0',
+            'REJECT_CODE' : '0',
+            'RRLP_STATUS' : '0',
+            'TMSI' : '0x4000003f',
+            'TMSI_ASSIGNED' : '0',
+            'WELCOME_SENT' : '1'
+    }
+
+    """
+    message = {
+      'command': 'tmsis',
+      'action': '',
+      'key': '',
+      'value': ''
+    }
+    return self._send_and_receive(message)
 
 class SIPAuthServe(BaseComponent):
   """Manages communication to the SIPAuthServe service.

--- a/openbts/tests/openbts_component_tests.py
+++ b/openbts/tests/openbts_component_tests.py
@@ -166,12 +166,22 @@ class OpenBTSNominalTMSIsTestCase(unittest.TestCase):
       'code': 200,
       'data': [
         {
-          'ACCESSED' : time.time() - 30,
-          'IMSI' : '901550000000084',
+          'IMSI': '901550000000084',
+          'TMSI': '0x40000000',
+          'IMEI': '355534065410400',
+          'AUTH': '2',
+          'CREATED': time.time() - 300,
+          'ACCESSED': time.time() - 30,
+          'TMSI_ASSIGNED': '0'
         },
         {
-          'ACCESSED' : time.time() - 180,
-          'IMSI' : '901550000000082',
+          'IMSI': '901550000000082',
+          'TMSI': '0x40000000',
+          'IMEI': '355534065410401',
+          'AUTH': '2',
+          'CREATED': time.time() - 900,
+          'ACCESSED': time.time() - 180,
+          'TMSI_ASSIGNED': '0'
         }
       ]
     })
@@ -184,7 +194,8 @@ class OpenBTSNominalTMSIsTestCase(unittest.TestCase):
       'command': 'tmsis',
       'action': 'read',
       'match': {'AUTH': '2'},
-      'fields': ['IMSI', 'ACCESSED']
+      'fields': [ 'IMSI', 'TMSI', 'IMEI', 'AUTH', 'CREATED', 'ACCESSED',
+                  'TMSI_ASSIGNED']
     })
     self.assertEqual(self.openbts_connection.socket.send.call_args[0],
                      (expected_message,))

--- a/openbts/tests/openbts_component_tests.py
+++ b/openbts/tests/openbts_component_tests.py
@@ -154,6 +154,38 @@ class OpenBTSNominalGetVersionTestCase(unittest.TestCase):
     self.assertTrue(self.openbts_connection.socket.recv.called)
     self.assertEqual(response.data, 'release 4.0.0.8025')
 
+class OpenBTSNominalTMSIsTestCase(unittest.TestCase):
+  """Testing the 'tmsis' command on the components.OpenBTS class."""
+
+  def setUp(self):
+    self.openbts_connection = OpenBTS()
+    # mock a zmq socket with a simple recv return value
+    self.openbts_connection.socket = mock.Mock()
+    self.openbts_connection.socket.recv.return_value = json.dumps({
+      'code': 200,
+      'data': {
+        'ACCESSED' : '33m',
+        'IMSI' : '901550000000084',
+        'TMSI' : '0x4000003f',
+      }
+    })
+
+  def test_tmsis(self):
+    """The 'tmsis' command should return a response."""
+    response = self.openbts_connection.tmsis()
+    self.assertTrue(self.openbts_connection.socket.send.called)
+    expected_message = json.dumps({
+      'command': 'tmsis',
+      'action': '',
+      'key': '',
+      'value': ''
+    })
+    self.assertEqual(self.openbts_connection.socket.send.call_args[0],
+                     (expected_message,))
+    self.assertTrue(self.openbts_connection.socket.recv.called)
+    self.assertEqual(response.data['ACCESSED'], '33m')
+    self.assertEqual(response.data['IMSI'], '901550000000084')
+    self.assertEqual(response.data['TMSI'], '0x4000003f')
 
 class OpenBTSNominalMonitorTestCase(unittest.TestCase):
   """Testing the 'monitor' command on the components.OpenBTS class."""

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ SMQueue, SIPAuthServe, and OpenBTS itself.
 
 
 ### requirements
-* OpenBTS 5.0 public alpha (tested on `aa72463`)
+* OpenBTS 5.0.2 public alpha (tested on `aa72463`)
 * Python 2.7
 
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ SMQueue, SIPAuthServe, and OpenBTS itself.
 
 
 ### requirements
-* OpenBTS 5.0 public alpha (tested on `11465a2`)
+* OpenBTS 5.0 public alpha (tested on `aa72463`)
 * Python 2.7
 
 
@@ -43,6 +43,11 @@ response = sipauthserve_connection.get_subscribers()
 print len(response.data)
 # 78
 
+# view tmsis entries
+response = openbts_connection.tmsis()
+print len(response)
+# 214
+
 # create a new subscriber by name, IMSI, MSIDSN and optional ki
 subscriber = ('ada', 0123, 4567, 8901)
 response = sipauthserve_connection.create_subscriber(*subscriber)
@@ -58,6 +63,7 @@ MIT
 
 
 ### releases
+* 0.1.1 - adds support for TMSIs
 * 0.1.0  - minor release!
 * 0.0.18 - fixes integration tests
 * 0.0.17 - sets `RCVTIME0` on zmq sockets

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ with open('readme.md') as f:
   readme = f.read()
 
 
-version = '0.1.0'
-
+version = '0.1.1'
 
 setup(
     name='openbts',


### PR DESCRIPTION
Allows you to make calls to `tmsis`, a command that already exists in openbts's nodemanager interface
