### PR TITLE
capture tower load data

### DIFF
--- a/integration_tests.py
+++ b/integration_tests.py
@@ -98,6 +98,15 @@ class OpenBTSTMSITableTest(unittest.TestCase):
     self.assertEqual(list, type(response))
 
 
+class OpenBTSLoadTest(unittest.TestCase):
+  """Tests the get_load functionality"""
+
+  def test_get_load(self):
+    connection = openbts.components.OpenBTS()
+    response = connection.get_load()
+    self.assertEqual(dict, type(response))
+
+
 class SIPAuthServeTest(unittest.TestCase):
   """Testing SIPAuthServe subscriber and number operations."""
 

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -69,14 +69,14 @@ class OpenBTS(BaseComponent):
       ],
     }
     try:
-        result = self._send_and_receive(message)
-        tmsis = result.data
+      result = self._send_and_receive(message)
+      tmsis = result.data
     except InvalidRequestError:
       return []
     if access_period > 0:
-        access_cutoff_time = time.time() - access_period
-        tmsis = filter(
-          lambda entry: entry['ACCESSED'] > access_cutoff_time, tmsis)
+      access_cutoff_time = time.time() - access_period
+      tmsis = filter(
+        lambda entry: entry['ACCESSED'] > access_cutoff_time, tmsis)
     return tmsis
 
   def get_load(self):

--- a/openbts/components.py
+++ b/openbts/components.py
@@ -101,7 +101,20 @@ class OpenBTS(BaseComponent):
       PCH: a paging channel for service notifications
       AGCH: a channel for transmitting BTS responses to channel requests
     """
-    pass
+    response = envoy.run('/OpenBTS/OpenBTSCLI -c "load"')
+    items = response.std_out.split()
+    return {
+      'sdcch_load': int(items[5].split('/')[0]),
+      'sdcch_available': int(items[5].split('/')[1]),
+      'tchf_load': int(items[8].split('/')[0]),
+      'tchf_available': int(items[8].split('/')[1]),
+      'pch_active': int(items[13].strip(',')),
+      'pch_total': int(items[14]),
+      'agch_active': int(items[19].strip(',')),
+      'agch_pending': int(items[20]),
+      'gprs_current_pdchs': int(items[26]),
+      'gprs_utilization_percentage': int(items[28].strip('%')),
+    }
 
 
 class SIPAuthServe(BaseComponent):

--- a/openbts/tests/fixtures/openbts_cli_load_output.txt
+++ b/openbts/tests/fixtures/openbts_cli_load_output.txt
@@ -1,0 +1,8 @@
+== GSM ==
+SDCCH load/available: 2/4
+TCH/F load/available: 1/3
+PCH load: active, total: 3, 7
+AGCH load: active, pending: 5, 9
+== GPRS ==
+current PDCHs: 4
+utilization: 41%

--- a/openbts/tests/openbts_component_tests.py
+++ b/openbts/tests/openbts_component_tests.py
@@ -155,6 +155,7 @@ class OpenBTSNominalGetVersionTestCase(unittest.TestCase):
     self.assertTrue(self.openbts_connection.socket.recv.called)
     self.assertEqual(response.data, 'release 4.0.0.8025')
 
+
 class OpenBTSNominalTMSIsTestCase(unittest.TestCase):
   """Testing the 'tmsis' command on the components.OpenBTS class."""
 
@@ -203,6 +204,7 @@ class OpenBTSNominalTMSIsTestCase(unittest.TestCase):
     self.assertEqual(len(response), 1)
     self.assertEqual(response[0]['IMSI'], '901550000000084')
 
+
 class OpenBTSNominalMonitorTestCase(unittest.TestCase):
   """Testing the 'monitor' command on the components.OpenBTS class."""
 
@@ -231,3 +233,41 @@ class OpenBTSNominalMonitorTestCase(unittest.TestCase):
                      (expected_message,))
     self.assertTrue(self.openbts_connection.socket.recv.called)
     self.assertEqual(response.data['noiseRSSI'], -68)
+
+
+class LoadTest(unittest.TestCase):
+  """Getting load data by invoking the OpenBTSCLI."""
+
+  @classmethod
+  def setUpClass(cls):
+    """We use envoy to call the OpenBTSCLI so we'll monkeypatch that module."""
+    cls.original_envoy = openbts.components.envoy
+    cls.mock_envoy = mocks.MockEnvoy(return_text=None)
+    openbts.components.envoy = cls.mock_envoy
+    cls.openbts = OpenBTS()
+    # Setup a path to the CLI output.
+    cls.cli_output_path = ('openbts/tests/fixtures/'
+                           'openbts_cli_load_output.txt')
+
+  @classmethod
+  def tearDownClass(cls):
+    """Repair the envoy monkeypatch."""
+    openbts.components.envoy = cls.original_envoy
+
+  def test_one(self):
+    """We can get load data."""
+    with open(self.cli_output_path) as output:
+        self.mock_envoy.return_text = output.read()
+    expected = {
+      'sdcch_load': 0,
+      'sdcch_available': 4,
+      'tchf_load': 0,
+      'tchf_available': 3,
+      'pch_active': 0,
+      'pch_total': 0,
+      'agch_active': 0,
+      'agch_pending': 0,
+      'gprs_current_pdchs': 4,
+      'gprs_utilization_percentage': 4,
+    }
+    self.assertEqual(expected, self.openbts.get_load())

--- a/openbts/tests/openbts_component_tests.py
+++ b/openbts/tests/openbts_component_tests.py
@@ -261,15 +261,15 @@ class LoadTest(unittest.TestCase):
     with open(self.cli_output_path) as output:
       self.mock_envoy.return_text = output.read()
     expected = {
-      'sdcch_load': 0,
+      'sdcch_load': 2,
       'sdcch_available': 4,
-      'tchf_load': 0,
+      'tchf_load': 1,
       'tchf_available': 3,
-      'pch_active': 0,
-      'pch_total': 0,
-      'agch_active': 0,
-      'agch_pending': 0,
+      'pch_active': 3,
+      'pch_total': 7,
+      'agch_active': 5,
+      'agch_pending': 9,
       'gprs_current_pdchs': 4,
-      'gprs_utilization_percentage': 4,
+      'gprs_utilization_percentage': 41,
     }
     self.assertEqual(expected, self.openbts.get_load())

--- a/openbts/tests/openbts_component_tests.py
+++ b/openbts/tests/openbts_component_tests.py
@@ -8,9 +8,11 @@ import unittest
 
 import mock
 
+import openbts
 from openbts.components import OpenBTS
 from openbts.exceptions import InvalidRequestError
-from openbts.codes import (SuccessCode, ErrorCode)
+from openbts.codes import SuccessCode
+from openbts.tests import mocks
 
 
 class OpenBTSNominalConfigTestCase(unittest.TestCase):
@@ -257,7 +259,7 @@ class LoadTest(unittest.TestCase):
   def test_one(self):
     """We can get load data."""
     with open(self.cli_output_path) as output:
-        self.mock_envoy.return_text = output.read()
+      self.mock_envoy.return_text = output.read()
     expected = {
       'sdcch_load': 0,
       'sdcch_available': 4,

--- a/readme.md
+++ b/readme.md
@@ -63,9 +63,10 @@ MIT
 
 
 ### releases
+* 0.1.3 - adds `components.OpenBTS.get_load`
 * 0.1.2 - version increment required for internal endaga project
 * 0.1.1 - adds support for TMSIs
-* 0.1.0  - minor release!
+* 0.1.0 - minor release!
 * 0.0.18 - fixes integration tests
 * 0.0.17 - sets `RCVTIME0` on zmq sockets
 * 0.0.16 - adds `envoy` to `setup.py`

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,31 @@
-"""setup
-openbts-python package definition
-"""
+"""The openbts-python package."""
+
 from setuptools import setup
 
 
 with open('readme.md') as f:
-  readme = f.read()
+  README = f.read()
 
 
-version = '0.1.2'
+VERSION = '0.1.3'
+
 
 setup(
-    name='openbts',
-    version=version,
-    description='OpenBTS NodeManager client',
-    long_description=readme,
-    url='http://github.com/endaga/openbts-python',
-    download_url=('https://github.com/endaga/openbts-python/tarball/%s' %
-                  version),
-    author='Matt Ball',
-    author_email='matt@endaga.com',
-    license='MIT',
-    packages=['openbts'],
-    install_requires=[
-        "enum34==1.0.4",
-        "envoy==0.0.3",
-        "pyzmq==14.5.0",
-    ],
-    zip_safe=False
+  name='openbts',
+  version=VERSION,
+  description='OpenBTS NodeManager client',
+  long_description=README,
+  url='http://github.com/endaga/openbts-python',
+  download_url=('https://github.com/endaga/openbts-python/tarball/%s' %
+                VERSION),
+  author='Matt Ball',
+  author_email='matt@endaga.com',
+  license='MIT',
+  packages=['openbts'],
+  install_requires=[
+    "enum34==1.0.4",
+    "envoy==0.0.3",
+    "pyzmq==14.5.0",
+  ],
+  zip_safe=False
 )


### PR DESCRIPTION
PTAL
- creates the `components.OpenBTS.get_load` method which, in an admittedly brittle manner, parses load data from the OpenBTS CLI
- seems like this data is printed by OpenBTS everytime in the same format (see `openbts/CLI/CLICommands.cpp` line 518)
- lints some stuff
